### PR TITLE
Support multiple chef servers in a aws accound in the same region.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ### Unreleased
 
+#### 0.3.1
+Just accidental issue with pre-release no real changes.
+
+#### 0.3.0
+Breaking Changes
+- requires the use of an arg to specify one or more values for an ec2 tag to filter on `-t tagName:TagVal1,TagVal2`. This is to allow multiple chef servers in the same aws account in the same region without creating false positives. This is do to the way CloudWatch event filtering works.
+
 #### 0.2.0
 - improving the notification message to be more user friendly
 - improving logic to be more user friendly

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ A mechanism for finding nodes that have spun up and not bootstrapped to chef
 
 The implementation is based on: https://github.com/eheydrick/aws-cleaner
 
+This application is under active development and is not production ready, there will be rapid and breaking changes for a bit and when we are ready we will release a 1.0 and then all breaking changes will be a major version bump regardless of the % of users it breaks.
 
 # Setup
 The setup for cloudwatch should be the same as aws-cleaner other than it should use a different queue name and should be the same other than the state should be "running" rather than terminated. here is an example of the event pattern:
@@ -22,6 +23,8 @@ The setup for cloudwatch should be the same as aws-cleaner other than it should 
 }
 ```
 
+You will also need to have some tag that we can filter on I recommend using something like the environment name or the chef_server name.
+
 ### Installation
 
 1. `gem install aws-watcher`
@@ -31,6 +34,7 @@ The setup for cloudwatch should be the same as aws-cleaner other than it should 
 ```
 Options:
   -c, --config=<s>    Path to config file (default: config.yml)
+  -t, --tag=<s>       Filters events by ec2 tag. Can supply multiple values (tagName:tagValue1,tagValue2)
   -h, --help          Show this message
 ```
 
@@ -40,8 +44,16 @@ and are strongly encouraged to use an IAM user with access limited to
 the AWS CloudWatch Events SQS queue.You will need to specify the region
 in the config even if you are using IAM Credentials.
 
-The app takes one arg '-c' that points at the config file. If -c is
-omitted it will look for the config file in the current directory.
+The app takes a configuration file via arg `-c`. If `-c` is omitted it will look for `config.yml` file in the current directory.
+
+Due to limitations on Cloudwatch alert filtering there is no way to support multiple chef servers in the same aws account and region without filtering on something like an aws tag. As such we decided to go a simple route and have this specified via arg `-t`. The idea is that many companies need multiple chef servers in the same aws account and in the same region but may be separated by business unit or environment.
+
+Example use cases for aws tags:
+- `environment:dev,qa`
+- `environment:prod1,prod2`
+- `chef_server:my_corp_biz_unit_chef_server`
+
+
 
 The app is started by running aws_watcher.rb and it will run until
 terminated. A production install would start it with upstart or
@@ -52,5 +64,10 @@ Example Notification:
 ![aws-watcher](https://raw.github.com/majormoses/aws-watcher/master/example-notification.png)
 
 ### Limitations
+#### Cloudwatch
+There are some limitations on cloudwatch and the ability to filter an event. Even if you have multiple vpcs providing isolation per account we cant filter without some information. I decided to go with an aws tag as this provides a simple way and fits my existing deployment model. See above for usage.
 
-None that I am aware of other than those specified in aws-cleaner which used for its simple libraries to accomplish similar tasks: https://github.com/eheydrick/aws-cleaner/blob/master/README.md#limitations
+#### aws-cleaner
+- the notification for Hipchat will always have 'AWS Cleaner' because this is hard coded in the upstream library. I have identified where and I will create a PR to fix that once my existing PRs are merged.
+
+In addtion please note the limitations in the upstream repository: https://github.com/eheydrick/aws-cleaner/blob/master/README.md#limitations

--- a/aws-watcher.gemspec
+++ b/aws-watcher.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'aws-watcher'
-  s.version     = '0.2.0'
+  s.version     = '0.3.1'
   s.summary     = 'AWS Watcher tracks EC2 instances being started to ensure they bootstrap to chef'
   s.description = s.summary
   s.authors     = ['Ben Abrams']

--- a/bin/aws_watcher.rb
+++ b/bin/aws_watcher.rb
@@ -37,6 +37,7 @@ end
 # get options
 opts = Trollop.options do
   opt :config, 'Path to config file', type: :string, default: 'config.yml'
+  opt :tag, 'tagName:tagValue1,tagValue2', type: String, required: true
 end
 
 @config = config(opts[:config])
@@ -44,6 +45,20 @@ end
 # initialize clients
 @sqs_client = AwsCleaner::SQS.client(@config)
 @chef_client = AwsCleaner::Chef.client(@config)
+
+# get tags
+begin
+  @tag_name = opts[:tag].split(':')[0].strip
+  @tag_values = opts[:tag].split(':')[1].split(',').strip
+  p "#{@tag_name}, #{@tag_values}"
+rescue
+  msg = "You passed be a tag of #{ops[:tag]} which is not valid "
+  msg += 'tags must look like this: -t tag:value you can'
+  msg += 'optionally pass multiple values for the same tag like '
+  msg += 'this -t tag:value1,value2'
+  p msg
+  exit 1
+end
 
 # start program in infinate loop
 loop do
@@ -53,9 +68,9 @@ loop do
     visibility_timeout: 3
   ).messages
 
-  puts "Got #{messages.size} message(s)"
+  puts "Got #{messages.size} message(s)" # unless messages.size.zero?
   messages.each_with_index do |message, index|
-    puts "Looking at message number #{index}" unless messages.size.zero?
+    puts "Looking at message number #{index}" # unless messages.size.zero?
     body = AwsCleaner.new.parse(message.body)
     id = message.receipt_handle
     now = Time.now.utc
@@ -80,6 +95,11 @@ loop do
     elsif AwsWatcher::Chef.registered?(@instance_id, @config)
       p "instance: #{@instance_id} has bootstrapped, removing message from queue"
       AwsCleaner.new.delete_message(id, @config)
+      next
+    elsif !AwsWatcher::EC2.tag_matches?(@instance_id, @tag_name, @tag_values, @config)
+      p "instance: #{@instance_id} has not bootstrap and was deleted because it did not have a tag of: #{@tag_name} matching one of these values: #{@tag_values}"
+      AwsCleaner.new.delete_message(id, @config)
+      next
     else
       p "instance: #{@instance_id}, launched: #{launch_time}, elapsed: #{elapsed_time} seconds"
     end

--- a/config.yml.sample
+++ b/config.yml.sample
@@ -39,4 +39,4 @@
       :variable: 'node'
       :method: 'get_chef_node_name'
       :argument: '@instance_id'
-:poll_time: 60:poll_time: 60
+:poll_time: 60

--- a/lib/aws-watcher.rb
+++ b/lib/aws-watcher.rb
@@ -36,6 +36,23 @@ class AwsWatcher
       end
       false
     end
+
+    def self.tag_matches?(id, tag, values, config)
+      instances = AwsWatcher::EC2.client(config).describe_instances(
+        instance_ids: [id],
+        filters: [
+          {
+            name: "tag:#{tag}",
+            values: values.to_a
+          }
+        ]
+      )
+      if instances.reservations.empty?
+        false
+      else
+        true
+      end
+    end
   end
 
   module Notify


### PR DESCRIPTION
Basically we need to be able to ignore messages that bootstrap against different chef servers in the same aws account and region. We accomplish this with the use of aws tags. This is a breaking change in the sense now you must specify a tag. 

Here are a couple examples:
- `./bin/aws_watcher.rb -t 'environment:dev,qa'`
- `./bin/aws_watcher.rb -t 'environment:prod-west-1,prod-east-1'`
- `./bin/aws_watcher.rb -t 'chef_server:my_chef_server_name'`